### PR TITLE
Add import statements to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The strategy requires a `verify` callback, which is where the custom logic goes 
 Here is the pseudo code:
 
 ```javascript
+import passportCustom from 'passport-custom';
+const CustomStrategy = passportCustom.Strategy;
+
 passport.use('strategy-name', new CustomStrategy(
   function(req, callback) {
     // Do your custom user finding logic here, or set to false based on req object


### PR DESCRIPTION
This might be the standard way to do it, but I didn't know that I had to do `passportCustom.Strategy` to get the strategy.

Worst case this just clarify things to people less used to that way of importing Strategies, like me.