### PR TITLE
Verify with options

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -57,12 +57,12 @@ Strategy.prototype.authenticate = function (req) {
 	}
 
 	try {
-        if (this._verify.length === 3) {
-            this._verify(req, options, verified);
-        }
-        else {
-            this._verify(req, verified);
-        }
+		if (this._verify.length === 3) {
+			this._verify(req, options, verified);
+		}
+		else {
+			this._verify(req, verified);
+		}
 	} catch (ex) {
 		return self.error(ex);
 	}

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -57,7 +57,12 @@ Strategy.prototype.authenticate = function (req) {
 	}
 
 	try {
-		this._verify(req, verified);
+        if (this._verify.length == 3) {
+            this._verify(req, options, verified);
+        }
+        else {
+            this._verify(req, verified);
+        }
 	} catch (ex) {
 		return self.error(ex);
 	}

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -43,7 +43,7 @@ util.inherits(Strategy, passport.Strategy);
  * @param {Object} req HTTP request object.
  * @api protected
  */
-Strategy.prototype.authenticate = function (req) {
+Strategy.prototype.authenticate = function (req, options) {
 	var self = this;
 
 	function verified(err, user, info) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -57,7 +57,7 @@ Strategy.prototype.authenticate = function (req) {
 	}
 
 	try {
-        if (this._verify.length == 3) {
+        if (this._verify.length === 3) {
             this._verify(req, options, verified);
         }
         else {

--- a/test/strategy.normal.test.js
+++ b/test/strategy.normal.test.js
@@ -37,4 +37,32 @@ describe('Strategy', function () {
 			expect(info.scope).to.equal('read');
 		});
 	});
+
+	describe('calling back with options', function () {
+
+		var optionsPassed;
+
+		var strategy = new Strategy(function (req, options, done) {
+			optionsPassed = options;
+			return done(null, { id: '1234' }, { scope: 'read' });
+		});
+
+		var options = { 'a': 'b' };
+
+		before(function (done) {
+			chai.passport(strategy)
+				.success(function (u, i) {
+					done();
+				})
+				.req(function (req) {
+					req.query = { };
+				})
+				.authenticate(options);
+		});
+
+		it('should pass options', function () {
+			expect(optionsPassed).to.be.an.object;
+			expect(optionsPassed).to.equal(options);
+		});
+	});
 });


### PR DESCRIPTION
Pass the options of authentication method to the verify callback. This allows the custom strategy to access those.

Done by checking the number of arguments of the callback for backward compatibility.