### PR TITLE
Restrict the User type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,7 +6,7 @@ export interface VerifyCallback {
 }
 
 export interface VerifiedCallback {
-    (error: any, user?: any, info?: any): void;
+    (error: any, user?: Express.User, info?: any): void;
 }
 
 export declare class Strategy extends PassportStrategy {


### PR DESCRIPTION
Please can we update the type of user from `any` to: `Express.User`?

Right now, there is nothing checking what gets passed to `done` matches the current definition of Express.User, which the user may have extended. 

See prior art:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/passport-oauth2/index.d.ts#L45

Please let me know your thoughts!