### PR TITLE
Use HTTPS package metadata URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "author": "Mike Bell <mbell8903@yahoo.com>",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mbell8903/passport-custom.git"
+    "url": "git+https://github.com/mbell8903/passport-custom.git"
   },
   "bugs": {
-    "url": "http://github.com/mbell8903/passport-custom/issues"
+    "url": "https://github.com/mbell8903/passport-custom/issues"
   },
   "licenses": [
     {


### PR DESCRIPTION
Summary:
- change the package repository URL from git:// to git+https://
- change the package bugs URL from http:// to https://

Validation:
- parsed package.json and asserted the updated repository and bugs URLs
- git diff --check
- git ls-remote https://github.com/mbell8903/passport-custom.git HEAD