### PR TITLE
Harden staged release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # Chai 5 and newer are ESM-only; this project's test harness is CommonJS.
+      - dependency-name: chai
+        update-types:
+          - version-update:semver-major
 
   # Track pinned GitHub Actions revisions separately from npm dependencies.
   - package-ecosystem: github-actions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,16 @@
-name: Stage npm package
+name: Test and stage npm package
 
 on:
   # Test proposed workflow and package changes before they reach master.
   pull_request:
     branches: [master]
 
-  # Stage future GitHub releases after they are published.
-  release:
-    types: [published]
+  # Stage a candidate when its release tag is pushed, before publishing a
+  # GitHub Release or changing npm's `latest` distribution tag.
+  push:
+    tags:
+      - "[0-9]*"
+      - "v[0-9]*"
 
   # Allow an existing version or commit to be staged manually.
   workflow_dispatch:
@@ -16,6 +19,11 @@ on:
         description: Git tag, branch, or commit to stage
         required: true
         default: master
+
+# Do not allow simultaneous attempts to stage the same source reference.
+concurrency:
+  group: npm-stage-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -59,7 +67,9 @@ jobs:
 
   stage:
     needs: test
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
 
     permissions:
@@ -72,14 +82,26 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          PUSH_TAG: ${{ github.ref_name }}
           MANUAL_REF: ${{ inputs.ref }}
         run: |
-          if [[ "$EVENT_NAME" == "release" ]]; then
-            echo "ref=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            source_ref="$PUSH_TAG"
+            is_version_tag=true
           else
-            echo "ref=$MANUAL_REF" >> "$GITHUB_OUTPUT"
+            source_ref="$MANUAL_REF"
+
+            # Treat semver-like manual references as tags so their version is
+            # checked before npm receives the package.
+            if [[ "$MANUAL_REF" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]]; then
+              is_version_tag=true
+            else
+              is_version_tag=false
+            fi
           fi
+
+          echo "ref=$source_ref" >> "$GITHUB_OUTPUT"
+          echo "is-version-tag=$is_version_tag" >> "$GITHUB_OUTPUT"
 
       - name: Check out release source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -100,15 +122,15 @@ jobs:
       - name: Verify package version
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          SOURCE_REF: ${{ steps.source.outputs.ref }}
+          IS_VERSION_TAG: ${{ steps.source.outputs.is-version-tag }}
         run: |
           package_version=$(node --print "require('./package.json').version")
 
-          if [[ "$EVENT_NAME" == "release" ]]; then
-            tag_version="${RELEASE_TAG#v}"
+          if [[ "$IS_VERSION_TAG" == "true" ]]; then
+            tag_version="${SOURCE_REF#v}"
             if [[ "$tag_version" != "$package_version" ]]; then
-              echo "Release tag $RELEASE_TAG does not match package version $package_version." >&2
+              echo "Release tag $SOURCE_REF does not match package version $package_version." >&2
               exit 1
             fi
           fi
@@ -122,8 +144,60 @@ jobs:
         run: npm ci
 
       - name: Inspect package contents
-        run: npm pack --dry-run
+        shell: bash
+        run: |
+          set -o pipefail
+          npm pack --dry-run --json | tee "$RUNNER_TEMP/npm-pack.json"
 
       - name: Stage package on npm
-        # Keep the existing stable release on `latest` until 1.2.0 is verified.
-        run: npm stage publish --tag next
+        id: npm-stage
+        shell: bash
+        env:
+          SOURCE_REF: ${{ steps.source.outputs.ref }}
+        run: |
+          # Preserve npm's output for review and extract the immutable stage ID
+          # that maintainers need for approval.
+          set +e
+          stage_output=$(npm stage publish --tag next 2>&1)
+          stage_status=$?
+          set -e
+          printf '%s\n' "$stage_output"
+
+          if (( stage_status != 0 )); then
+            exit "$stage_status"
+          fi
+
+          stage_id=$(
+            sed -nE 's/.*staged with id ([^)]+).*/\1/p' <<< "$stage_output" |
+              tail -n 1
+          )
+
+          if [[ -z "$stage_id" ]]; then
+            echo "npm did not return a staged-package ID." >&2
+            exit 1
+          fi
+
+          package_version=$(node --print "require('./package.json').version")
+          shasum=$(
+            node --input-type=module --eval \
+              "import fs from 'node:fs'; console.log(JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + '/npm-pack.json'))[0].shasum)"
+          )
+          integrity=$(
+            node --input-type=module --eval \
+              "import fs from 'node:fs'; console.log(JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + '/npm-pack.json'))[0].integrity)"
+          )
+
+          echo "stage-id=$stage_id" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### npm staged package"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Package | \`passport-custom@$package_version\` |"
+            echo "| Source | \`$SOURCE_REF\` |"
+            echo "| Stage ID | \`$stage_id\` |"
+            echo "| Distribution tag | \`next\` |"
+            echo "| SHA-1 | \`$shasum\` |"
+            echo "| Integrity | \`$integrity\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,90 @@
+# Releasing passport-custom
+
+This project uses npm trusted publishing and staged publishing so a package is
+reviewed before it becomes the default installation.
+
+## Prerequisites
+
+- The npm trusted publisher must reference `mbell8903/passport-custom` and the
+  `publish.yml` workflow, with `npm stage publish` allowed.
+- The maintainer approving or promoting a package must have npm two-factor
+  authentication enabled.
+- The release commit must be merged into `master` with all required checks
+  passing.
+
+## Prepare the release
+
+1. Update `CHANGELOG.md` with the release version and date.
+2. Update `package.json` and `package-lock.json` without creating a tag:
+
+   ```sh
+   npm version <version> --no-git-tag-version
+   ```
+
+3. Run the release checks:
+
+   ```sh
+   npm ci
+   npm test
+   npm run coverage:check
+   npm run typecheck
+   npm pack --dry-run
+   ```
+
+4. Merge the release pull request into `master`.
+
+## Stage the package
+
+Create an annotated tag from the final `master` commit and push it:
+
+```sh
+git switch master
+git pull --ff-only
+git tag -a <version> -m "<version>"
+git push origin <version>
+```
+
+Pushing the tag runs the Node.js 18, 20, 22, and 24 test matrix. If every check
+passes, the workflow submits the package to npm staged publishing under the
+`next` distribution tag. It does not change `latest`.
+
+Review the workflow summary and confirm:
+
+- the source commit and tag are correct;
+- the package version matches the tag;
+- the package file list is expected;
+- the SHA-1 and SHA-512 integrity match npm's staged-package view;
+- npm generated a provenance statement for the GitHub Actions run.
+
+Approve the candidate from npm's **Staged Packages** page using two-factor
+authentication.
+
+## Publish the release
+
+After approval, verify the candidate from an unauthenticated registry request:
+
+```sh
+npm view passport-custom@next version dist.shasum dist.integrity gitHead --json
+```
+
+Publish the matching GitHub Release, then promote the reviewed version:
+
+```sh
+npm dist-tag add passport-custom@<version> latest
+npm view passport-custom dist-tags --json
+```
+
+Both `latest` and `next` should now resolve to the released version.
+
+## Recovery
+
+Published npm versions are immutable. If a serious regression is discovered,
+move `latest` back to the previous known-good version while preparing a new
+patch release:
+
+```sh
+npm dist-tag add passport-custom@<previous-version> latest
+```
+
+Do not delete or move a published Git tag, and do not attempt to replace an npm
+version that has already been published.


### PR DESCRIPTION
## What changed

- stage npm candidates when a version tag is pushed, before publishing the GitHub Release
- keep manual staging available while validating semver-like references against `package.json`
- serialize attempts for the same source reference
- publish the npm stage ID, source, SHA-1, and integrity in the Actions job summary
- preserve failed npm output in Actions logs
- document the complete prepare, stage, approve, promote, verify, and recovery process in `RELEASING.md`
- prevent Dependabot from proposing ESM-only Chai major versions while the test harness remains CommonJS

## Why

The 1.2.0 release exposed two workflow gaps: the GitHub Release had to be published before npm staging began, and the staging result had to be recovered manually from raw job logs. This makes the intended safety order explicit and gives maintainers the identifiers needed to review a candidate before changing `latest`.

## Impact

Pull requests still run the Node.js 18, 20, 22, and 24 test matrix. Future version-tag pushes run that matrix and stage the package under `next`; they do not directly publish to `latest`.

## Validation

- YAML parsed locally
- Node.js 18 unit tests
- Node.js 24 unit tests
- coverage thresholds: 100% lines/functions and 90.91% branches
- TypeScript declaration consumer test
- `npm pack --dry-run`
- Git diff whitespace validation